### PR TITLE
Fix admin submission checkboxes

### DIFF
--- a/app/admin/subm-admin-list.tsx
+++ b/app/admin/subm-admin-list.tsx
@@ -112,9 +112,16 @@ export default function SubmAdminList({ submPage }: { submPage: PaginatedSubmLis
                         render: (subm) => (
                             <div className="flex justify-center items-center">
                                 <Checkbox
+                                    aria-label={`Select submission ${subm.subm_uuid}`}
                                     isSelected={selectedSubmissions.has(subm.subm_uuid)}
                                     onChange={(isChecked) => handleCheckboxChange(subm.subm_uuid, isChecked)}
-                                />
+                                >
+                                    <Checkbox.Content>
+                                        <Checkbox.Control className="size-5">
+                                            <Checkbox.Indicator />
+                                        </Checkbox.Control>
+                                    </Checkbox.Content>
+                                </Checkbox>
                             </div>
                         )
                     },

--- a/docs/heroui-v3.md
+++ b/docs/heroui-v3.md
@@ -1,0 +1,9 @@
+# HeroUI v3 component composition
+
+HeroUI v3 checkboxes use a compound component API.
+A bare `<Checkbox />` renders the field root but no visible checkbox control.
+Wrap `Checkbox.Control` and `Checkbox.Indicator` in `Checkbox.Content`, which provides the clickable element.
+For an icon-only checkbox, omit the visible label and set `aria-label` on `Checkbox`.
+
+This applies to checkbox usage under `app/`, including the admin submission list and scoring pages.
+After changing a checkbox, open the affected page, verify that the control is visible, and toggle it to confirm that `isSelected` and `onChange` remain connected.


### PR DESCRIPTION
## Summary
- restore visible, interactive selection checkboxes in the admin submission list
- document the required HeroUI v3 checkbox composition

## Test plan
- [x] Run ESLint on `app/admin/subm-admin-list.tsx`
- [x] Run `yarn tsc --noEmit`
- [ ] Verify checkbox selection on `/admin` with an authenticated admin account

Made with [Cursor](https://cursor.com)