### PR TITLE
Add server-side admin API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ Create `.env.local` when overriding the production API:
 ```dotenv
 NEXT_PUBLIC_API_HOST=http://localhost:8080
 SERVER_API_HOST=http://localhost:8080
+ADMIN_API_KEY=replace-with-a-separate-long-random-secret
 ```
 
 `NEXT_PUBLIC_API_HOST` is used by the browser.
 `SERVER_API_HOST` is used by server-side requests and defaults to `NEXT_PUBLIC_API_HOST`.
 Both ultimately default to `https://api.programme.lv`.
+`ADMIN_API_KEY` authenticates server-side requests to protected backend endpoints and must match the backend value.
+Never expose it through a `NEXT_PUBLIC_` variable or browser-side code.
 
 ## Commands
 

--- a/app/(platform)/submissions/[subm_id]/page.tsx
+++ b/app/(platform)/submissions/[subm_id]/page.tsx
@@ -1,4 +1,4 @@
-import { getExec } from "@/lib/subms";
+import { getExec } from "@/lib/exec/get";
 import Layout from "@/components/layout";
 import SubmInfoHeader from "./header";
 import CodeBlock from "@/components/code-block";

--- a/app/(platform)/submissions/[subm_id]/page.tsx
+++ b/app/(platform)/submissions/[subm_id]/page.tsx
@@ -30,7 +30,10 @@ export default async function Page({
 	if (!submData || !submData.curr_eval)
 		return <>Error: submission data is empty.</>;
 
-	const execData = await getExec(submData.curr_eval.eval_uuid);
+	const execData = await getExec(
+		submData.curr_eval.eval_uuid,
+		Boolean(submData.content),
+	);
 	if (!execData) return <>Error: execution data is empty.</>;
 
 	const breadcrumbs = [

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -13,6 +13,7 @@ services:
     environment:
       NEXT_PUBLIC_API_HOST: "https://api.programme.lv"
       SERVER_API_HOST: "http://backend:8080"
+      ADMIN_API_KEY: "replace-with-a-separate-long-random-secret"
     ports:
       - "3000:3000"
     depends_on:
@@ -34,6 +35,7 @@ services:
       dockerfile: Dockerfile
     environment:
       JWT_KEY: "replace-with-a-long-random-secret"
+      ADMIN_API_KEY: "replace-with-a-separate-long-random-secret"
       COOKIE_DOMAIN: "localhost"
 
       POSTGRES_HOST: "postgres"

--- a/docs/backend-admin-authentication.md
+++ b/docs/backend-admin-authentication.md
@@ -1,0 +1,13 @@
+# Backend admin authentication
+
+The backend supports `Authorization: Bearer <ADMIN_API_KEY>` for server-to-server access to admin-only endpoints.
+The website uses this credential for server-rendered requests that cannot rely on the browser's `auth_token` cookie, including execution detail retrieval.
+
+`ADMIN_API_KEY` is a runtime-only server environment variable and must equal the backend value.
+It must not use the `NEXT_PUBLIC_` prefix, appear in client components, or be forwarded to the browser.
+Server-only modules that use the key must import `server-only`.
+
+Browser-initiated admin operations continue to use the signed-in administrator's cookie.
+Do not replace that authorization with an unguarded server action using the shared key, because server actions are externally callable and would otherwise grant backend admin privileges.
+
+To verify the integration, configure the same key for the website and backend, then open a submission details page and confirm its execution results load.

--- a/lib/exec/get.ts
+++ b/lib/exec/get.ts
@@ -1,0 +1,25 @@
+import "server-only";
+
+import { Execution } from "@/types/exec";
+import { SERVER_API_HOST } from "@/lib/config";
+import { getAdminApiKey } from "@/lib/server-config";
+
+export const getExec = async (execUuid: string): Promise<Execution> => {
+  const response = await fetch(
+    `${SERVER_API_HOST}/exec/${encodeURIComponent(execUuid)}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${getAdminApiKey()}`,
+      },
+    },
+  );
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw { response: { data } };
+  }
+
+  return data.data;
+};

--- a/lib/exec/get.ts
+++ b/lib/exec/get.ts
@@ -1,10 +1,30 @@
 import "server-only";
 
-import { Execution } from "@/types/exec";
+import { Execution, TestRes } from "@/types/exec";
 import { SERVER_API_HOST } from "@/lib/config";
 import { getAdminApiKey } from "@/lib/server-config";
 
-export const getExec = async (execUuid: string): Promise<Execution> => {
+function stripTestDetails(test: TestRes): TestRes {
+  return {
+    ...test,
+    inp: null,
+    ans: null,
+    subm_rd: test.subm_rd
+      ? {
+          ...test.subm_rd,
+          in: "",
+          out: "",
+          err: "",
+        }
+      : null,
+    tlib_rd: null,
+  };
+}
+
+export const getExec = async (
+  execUuid: string,
+  includeTestDetails: boolean,
+): Promise<Execution> => {
   const response = await fetch(
     `${SERVER_API_HOST}/exec/${encodeURIComponent(execUuid)}`,
     {
@@ -21,5 +41,11 @@ export const getExec = async (execUuid: string): Promise<Execution> => {
     throw { response: { data } };
   }
 
-  return data.data;
+  const execution: Execution = data.data;
+
+  if (!includeTestDetails) {
+    execution.test_res = execution.test_res.map(stripTestDetails);
+  }
+
+  return execution;
 };

--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -1,0 +1,11 @@
+import "server-only";
+
+export function getAdminApiKey(): string {
+  const adminApiKey = process.env.ADMIN_API_KEY;
+
+  if (!adminApiKey) {
+    throw new Error("ADMIN_API_KEY is not configured");
+  }
+
+  return adminApiKey;
+}

--- a/lib/subms.ts
+++ b/lib/subms.ts
@@ -1,5 +1,4 @@
 import { API_HOST } from "./config";
-import { Execution } from "@/types/exec";
 import { SubmListEntry, SubmListSseUpdate } from "@/types/subm";
 import { MaxScorePerTask } from "@/types/scores";
 
@@ -74,23 +73,6 @@ export function subscribeToSubmUpdates(
   return () => {
     eventSource.close();
   };
-};
-
-export const getExec = async (execUuid: string): Promise<Execution> => {
-  const response = await fetch(`${API_HOST}/exec/${execUuid}`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-
-  const data = await response.json();
-
-  if (!response.ok) {
-    throw { response: { data } };
-  }
-
-  return data.data;
 };
 
 export const getMaxScorePerTask = async (username: string): Promise<MaxScorePerTask> => {


### PR DESCRIPTION
## Summary
- add server-only `ADMIN_API_KEY` configuration
- authenticate execution detail requests with the backend Bearer credential
- document local and Compose configuration without exposing the key client-side

## Test plan
- [x] Build the production image with Docker
- [x] Run ESLint in a Node 22 container
- [ ] Configure matching website and backend keys and open a submission details page

Made with [Cursor](https://cursor.com)