### PR TITLE
semantic versioning and building

### DIFF
--- a/.cursor/rules/releases.mdc
+++ b/.cursor/rules/releases.mdc
@@ -1,0 +1,35 @@
+---
+description: SemVer git tags drive Docker image publishes; pin production deploys to release tags
+alwaysApply: true
+---
+
+# Container releases
+
+Docker images are published **only** when an annotated SemVer git tag matching `v*` is pushed.
+Merges to `main` do not build or push images.
+
+## Versioning
+
+- Independent SemVer for this repo: `vMAJOR.MINOR.PATCH` (start production baseline at `v1.0.0`).
+- `PATCH`: fixes, security, internal changes with no deploy/API/config break.
+- `MINOR`: backward-compatible features.
+- `MAJOR`: incompatible API, config, or deployment changes.
+- Never move or overwrite a release tag.
+- Ignore historical `v0.x` tags from older divergent history; do not continue that series on current `main`.
+- `package.json` version is not the release source of truth; git tags are.
+
+## Publish flow
+
+1. Merge the release commit to `main`.
+2. Create an annotated tag on that commit, e.g. `git tag -a v1.2.0 -m "v1.2.0" && git push origin v1.2.0`.
+3. Workflow `.github/workflows/publish-ghcr.yml` builds and pushes to `ghcr.io/programme-lv/website` with tags: the SemVer ref, short SHA, and mutable `latest`.
+
+## Deploy
+
+- Pin production Compose to the SemVer tag, e.g. `ghcr.io/programme-lv/website:v1.2.0`.
+- Never deploy `:latest` in production.
+- `docker compose restart` does not pull new images. Use `docker compose pull && docker compose up -d`.
+- Backend and website versions are independent; bump each only when that service changes.
+- Roll back by restoring the previous Compose image tag and pulling/up again.
+
+Project-wide release policy also lives in `../docs/github/container-releases.md`.

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -2,11 +2,8 @@ name: Publish Docker image
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -43,10 +40,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
           tags: |
-            type=ref,event=branch
             type=ref,event=tag
-            type=sha,prefix={{branch}}-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+            type=raw,value=latest
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -2,7 +2,7 @@
 # Replace placeholder values before deploying.
 services:
   website:
-    # image: ghcr.io/programme-lv/website:latest
+    # image: ghcr.io/programme-lv/website:v1.0.0
     # To build this repo locally instead of pulling from GHCR, comment out
     # image above and uncomment:
     build:
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
 
   backend:
-    # image: ghcr.io/programme-lv/backend:latest
+    # image: ghcr.io/programme-lv/backend:v1.0.0
     # To build the sibling backend repo locally instead of pulling from GHCR,
     # comment out image above and uncomment:
     build:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when images are built and pushed; teams that relied on every `main` merge for GHCR updates must adopt explicit tagging or releases will stop until a tag is pushed.
> 
> **Overview**
> **Shifts container publishing from `main` merges to SemVer git tags** (`v*`), and documents how to version, tag, and deploy.
> 
> The GHCR workflow no longer runs on pushes to `main` or `workflow_dispatch`; it triggers only on `v*` tag pushes. Image metadata drops branch-based tags and always applies `latest` plus short SHA alongside the SemVer tag (instead of `latest` only on the default branch).
> 
> Adds **`.cursor/rules/releases.mdc`** (always-on) describing independent SemVer per repo, annotated tag publish steps, production pinning (no `:latest`), and pull/up deploy notes. **`compose.example.yml`** example comments now show `v1.0.0` image pins instead of `:latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6589b95e8f94da3a9ae4f8138a583c327573f6a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->