### PR TITLE
Add forgot/reset/verify auth UI

### DIFF
--- a/app/(auth)/forgot-password/layout.tsx
+++ b/app/(auth)/forgot-password/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Aizmirsāt paroli",
+};
+
+export default function ForgotPasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { requestPasswordReset } from "@/lib/auth";
+import Alert from "@/components/alert";
+import AuthField from "@/components/auth-field";
+import GenericButton from "@/components/generic-button";
+import AuthCardWithBG from "@/components/auth-card-with-bg";
+import { IconSend } from "@tabler/icons-react";
+
+export default function ForgotPasswordPage() {
+  const [login, setLogin] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: () => requestPasswordReset(login),
+    onMutate: () => setError(null),
+    onSuccess: (response) => {
+      if (response.status === "success") {
+        setDone(true);
+        return;
+      }
+      setError(response.message || "Neizdevās nosūtīt e-pastu");
+    },
+    onError: () => setError("Neizdevās nosūtīt e-pastu"),
+  });
+
+  return (
+    <AuthCardWithBG type="forgot-password">
+      <div className="flex flex-col gap-6">
+        <div>
+          <h1 className="text-[1.75rem] font-normal leading-tight tracking-tight text-[#161616]">
+            Aizmirsāt paroli?
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-[#525252]">
+            Ievadiet lietotājvārdu vai e-pastu. Ja konts eksistē, nosūtīsim
+            atjaunošanas saiti.
+          </p>
+        </div>
+
+        {done ? (
+          <Alert
+            message="Ja konts eksistē, e-pasts ar norādījumiem ir nosūtīts."
+            type="success"
+            onClose={() => setDone(false)}
+          />
+        ) : (
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              mutation.mutate();
+            }}
+          >
+            <AuthField
+              label="Lietotājvārds vai e-pasts"
+              name="login"
+              autoComplete="username"
+              required
+              disabled={mutation.isPending}
+              value={login}
+              onChange={setLogin}
+            />
+            <GenericButton
+              className="mt-2 !h-[44px] w-full !justify-between px-4 text-[0.95rem] !font-normal !bg-[#0f62fe] hover:!bg-[#0353e9]"
+              isLoading={mutation.isPending}
+              rounded="sm"
+              type="submit"
+              variant="primary"
+              icon={<IconSend size={20} stroke={1.75} />}
+            >
+              Nosūtīt saiti
+            </GenericButton>
+          </form>
+        )}
+
+        {error && (
+          <Alert message={error} type="error" onClose={() => setError(null)} />
+        )}
+      </div>
+    </AuthCardWithBG>
+  );
+}

--- a/app/(auth)/reset-password/layout.tsx
+++ b/app/(auth)/reset-password/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Atjaunot paroli",
+};
+
+export default function ResetPasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter, useSearchParams } from "next/navigation";
+import { confirmPasswordReset } from "@/lib/auth";
+import Alert from "@/components/alert";
+import AuthField from "@/components/auth-field";
+import GenericButton from "@/components/generic-button";
+import { TextLink } from "@/components/text-link";
+import AuthCardWithBG from "@/components/auth-card-with-bg";
+import { IconKey } from "@tabler/icons-react";
+
+function ResetPasswordForm() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get("token") ?? "";
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: () => confirmPasswordReset(token, password),
+    onMutate: () => setError(null),
+    onSuccess: (response) => {
+      if (response.status === "success") {
+        router.push("/login");
+        return;
+      }
+      setError(response.message || "Neizdevās atjaunot paroli");
+    },
+    onError: () => setError("Neizdevās atjaunot paroli"),
+  });
+
+  if (!token) {
+    return (
+      <div className="flex flex-col gap-6">
+        <h1 className="text-[1.75rem] font-normal leading-tight tracking-tight text-[#161616]">
+          Atjaunot paroli
+        </h1>
+        <Alert
+          message="Trūkst derīgas atjaunošanas saites."
+          type="error"
+          onClose={() => undefined}
+        />
+        <p className="text-sm">
+          <TextLink color="default" weight="medium" href="/forgot-password">
+            Pieprasīt jaunu saiti
+          </TextLink>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-[1.75rem] font-normal leading-tight tracking-tight text-[#161616]">
+          Jauna parole
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-[#525252]">
+          Ievadiet jauno paroli (vismaz 8 simboli).
+        </p>
+      </div>
+      <form
+        className="flex flex-col gap-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (password !== confirm) {
+            setError("Paroles nesakrīt");
+            return;
+          }
+          mutation.mutate();
+        }}
+      >
+        <AuthField
+          label="Jaunā parole"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          required
+          disabled={mutation.isPending}
+          value={password}
+          onChange={setPassword}
+        />
+        <AuthField
+          label="Apstipriniet paroli"
+          name="confirmPassword"
+          type="password"
+          autoComplete="new-password"
+          required
+          disabled={mutation.isPending}
+          value={confirm}
+          onChange={setConfirm}
+        />
+        {error && (
+          <Alert message={error} type="error" onClose={() => setError(null)} />
+        )}
+        <GenericButton
+          className="mt-2 !h-[44px] w-full !justify-between px-4 text-[0.95rem] !font-normal !bg-[#0f62fe] hover:!bg-[#0353e9]"
+          isLoading={mutation.isPending}
+          rounded="sm"
+          type="submit"
+          variant="primary"
+          icon={<IconKey size={20} stroke={1.75} />}
+        >
+          Saglabāt paroli
+        </GenericButton>
+      </form>
+      <p className="text-sm">
+        <TextLink color="default" weight="medium" href="/login">
+          Atpakaļ uz pieslēgšanos
+        </TextLink>
+      </p>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <AuthCardWithBG type="reset-password">
+      <Suspense>
+        <ResetPasswordForm />
+      </Suspense>
+    </AuthCardWithBG>
+  );
+}

--- a/app/(auth)/verify-email/layout.tsx
+++ b/app/(auth)/verify-email/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Apstiprināt e-pastu",
+};
+
+export default function VerifyEmailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/(auth)/verify-email/page.tsx
+++ b/app/(auth)/verify-email/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { confirmEmailVerification } from "@/lib/auth";
+import Alert from "@/components/alert";
+import { TextLink } from "@/components/text-link";
+import AuthCardWithBG from "@/components/auth-card-with-bg";
+
+function VerifyEmailContent() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+  const [status, setStatus] = useState<"loading" | "success" | "error">(
+    token ? "loading" : "error"
+  );
+  const [message, setMessage] = useState(
+    token ? "Apstiprinām e-pastu…" : "Trūkst derīgas apstiprinājuma saites."
+  );
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+    let cancelled = false;
+    confirmEmailVerification(token).then((response) => {
+      if (cancelled) {
+        return;
+      }
+      if (response.status === "success") {
+        setStatus("success");
+        setMessage("E-pasts apstiprināts.");
+        return;
+      }
+      setStatus("error");
+      setMessage(response.message || "Neizdevās apstiprināt e-pastu.");
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h1 className="text-[1.75rem] font-normal leading-tight tracking-tight text-[#161616]">
+        E-pasta apstiprināšana
+      </h1>
+      <Alert
+        message={message}
+        type={
+          status === "error" ? "error" : status === "success" ? "success" : "info"
+        }
+        onClose={() => undefined}
+      />
+      <p className="text-sm">
+        <TextLink color="default" weight="medium" href="/login">
+          Uz pieslēgšanos
+        </TextLink>
+      </p>
+    </div>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <AuthCardWithBG type="verify-email">
+      <Suspense>
+        <VerifyEmailContent />
+      </Suspense>
+    </AuthCardWithBG>
+  );
+}

--- a/components/auth-card-with-bg.tsx
+++ b/components/auth-card-with-bg.tsx
@@ -1,47 +1,40 @@
 "use client";
 
 import React, { Suspense } from "react";
-import Image from "next/image";
-import Link from "next/link";
 
-import Buyukada from "@/public/buyukada-island2.webp";
-import LogoImage from "@/public/emoji-logo.png";
 import AuthForm from "./auth-form";
 
-export default function AuthCardWithBG(props: { type: "login" | "register" }) {
-  const { type } = props;
+type AuthCardType =
+  | "login"
+  | "register"
+  | "forgot-password"
+  | "reset-password"
+  | "verify-email";
+
+export default function AuthCardWithBG(props: {
+  type?: AuthCardType;
+  children?: React.ReactNode;
+}) {
+  const { type = "login", children } = props;
 
   return (
-    <div
-      className="flex min-h-screen relative w-screen items-center justify-center overflow-hidden bg-content1 p-2 pt-16 lg:px-8"
-      style={{
-        backgroundColor: "rgba(0, 0, 0, 0.5)",
-        backgroundPosition: "center",
-      }}
-    >
-      {/* Brand Logo */}
-      <div className="absolute left-2 top-2">
-        <Link
-          className="flex items-center p-2 bg-white rounded-sm hover:bg-gray-50"
-          href="/"
-        >
-          <Image alt="programme.lv logo" height={22} src={LogoImage} />
-          <p
-            className="ms-2 me-1 dark:text-white text-medium font-mono text-default-800"
-            style={{ fontFamily: "sans-serif" }}
-          >
-            programme.lv
-          </p>
-        </Link>
-      </div>
+    <div className="flex min-h-screen w-full flex-col bg-white">
+      {/* Top spacer only when viewport has room; no brand mark */}
+      <div
+        aria-hidden
+        className="shrink-0 h-[clamp(0.75rem,10vh,5.5rem)]"
+      />
 
-
-      {/* Auth Form */}
-      <Suspense>
-        <div className="px-4 py-2 w-full max-w-md bg-white rounded-sm">
-          <AuthForm type={type} />
+      <main className="flex flex-1 justify-center px-4 pb-[clamp(1.5rem,8vh,4rem)] sm:px-6">
+        <div className="w-full max-w-[22.5rem]">
+          <Suspense>
+            {children ??
+              (type === "login" || type === "register" ? (
+                <AuthForm type={type} />
+              ) : null)}
+          </Suspense>
         </div>
-      </Suspense>
+      </main>
     </div>
   );
 }

--- a/components/auth-field.tsx
+++ b/components/auth-field.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useId } from "react";
+
+type AuthFieldProps = {
+  label: string;
+  name: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: string;
+  autoComplete?: string;
+  required?: boolean;
+  disabled?: boolean;
+  endContent?: React.ReactNode;
+  "aria-label"?: string;
+};
+
+export default function AuthField({
+  label,
+  name,
+  value,
+  onChange,
+  type = "text",
+  autoComplete,
+  required,
+  disabled,
+  endContent,
+  "aria-label": ariaLabel,
+}: AuthFieldProps) {
+  const id = useId();
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={id} className="text-sm text-[#525252]">
+        {label}
+      </label>
+      <div className="auth-field-shell relative">
+        <input
+          id={id}
+          name={name}
+          type={type}
+          autoComplete={autoComplete}
+          required={required}
+          disabled={disabled}
+          aria-label={ariaLabel ?? label}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className={`auth-field-input box-border h-[44px] w-full px-4 text-[0.95rem] leading-none text-[#161616] placeholder:text-[#a8a8a8] disabled:cursor-not-allowed disabled:opacity-50 ${
+            endContent ? "pr-10" : ""
+          }`}
+        />
+        {endContent ? (
+          <div className="absolute inset-y-0 right-2 z-10 flex items-center">
+            {endContent}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/auth-form.tsx
+++ b/components/auth-form.tsx
@@ -1,20 +1,17 @@
-import { useState, useContext, useEffect } from "react";
+import { useState, useContext, useEffect, Suspense } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { AuthContext } from "@/app/providers";
 import { registerUser, loginUser } from "@/lib/auth";
 import Alert from "@/components/alert";
-import { Suspense } from "react";
 import { User } from "@/types/proglv";
 import GenericButton from "./generic-button";
+import AuthField from "./auth-field";
 import { IconEye, IconEyeOff, IconLogin2, IconUserPlus } from "@tabler/icons-react";
 import { TextLink } from "./text-link";
-import { Input, Label } from "@heroui/react";
-
+import Link from "next/link";
 
 function FormatError(error: string) {
-  // capitalize first letter
-  // add dot at the end
   return error.charAt(0).toUpperCase() + error.slice(1) + ".";
 }
 
@@ -83,11 +80,9 @@ export default function AuthForm({
           email: user.email,
           firstname: user.firstname,
           lastname: user.lastname,
-        } as User)
+        } as User);
 
         setIsRedirecting(true);
-
-        // Use hard navigation to ensure server components re-fetch data with new auth state
         window.location.href = redirectParam || "/tasks";
       } else {
         setError(FormatError(response.message));
@@ -103,7 +98,6 @@ export default function AuthForm({
     if (type === "register") {
       if (password !== repPassword) {
         setError("Paroles nesakrīt!");
-
         return;
       }
       registerMutation.mutate({
@@ -118,171 +112,149 @@ export default function AuthForm({
     }
   };
 
-  const disableInputs = loginMutation.status === 'pending' || registerMutation.status === 'pending' || isRedirecting;
+  const disableInputs =
+    loginMutation.status === "pending" ||
+    registerMutation.status === "pending" ||
+    isRedirecting;
 
   return (
-    <div className="flex w-full flex-col gap-4 pb-4 pt-4">
-      <p className="pb-2 text-xl flex gap-x-2">
-        {type === "register" ? (
-          <>
-            <span>Reģistrācija</span>
-          </>
-        ) : (
-          <>Sveicināts!</>
-        )}
-      </p>
-      <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
-        <div className="flex flex-col gap-1">
-          <Label>Lietotājvārds</Label>
-          <Input
-            aria-label="Lietotājvārds"
-            autoComplete="username"
-            className="border-divider border rounded-md py-3"
-            disabled={disableInputs}
-            name="username"
-            required
-            value={username}
-            variant="secondary"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUsername(e.target.value)}
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-[1.75rem] font-normal leading-tight tracking-tight text-[#161616]">
+          {type === "register" ? "Izveidot kontu" : "Pieslēgties"}
+        </h1>
+        <Suspense>
+          <GoToLoginOrRegister
+            type={type}
+            redirect={redirectParam ?? undefined}
+            onSwitchToLogin={onSwitchToLogin}
+            onSwitchToRegister={onSwitchToRegister}
           />
-        </div>
+        </Suspense>
+      </div>
+
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <AuthField
+          label="Lietotājvārds"
+          name="username"
+          autoComplete="username"
+          required
+          disabled={disableInputs}
+          value={username}
+          onChange={setUsername}
+        />
+
         {type === "register" && (
           <>
-            <div className="flex flex-col md:flex-row gap-3">
-              <div className="flex flex-1 flex-col gap-1">
-                <Label>Vārds (neobligāts)</Label>
-                <Input
-                  aria-label="Vārds (neobligāts)"
-                  className="border-divider border rounded-md py-3"
-                  disabled={disableInputs}
+            <div className="flex flex-col gap-4 sm:flex-row sm:gap-3">
+              <div className="flex-1">
+                <AuthField
+                  label="Vārds (neobligāts)"
                   name="firstName"
-                  value={firstName}
-                  variant="secondary"
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setFirstName(e.target.value)}
-                />
-              </div>
-              <div className="flex flex-1 flex-col gap-1">
-                <Label>Uzvārds (neobligāts)</Label>
-                <Input
-                  aria-label="Uzvārds (neobligāts)"
-                  className="border-divider border rounded-md py-3"
                   disabled={disableInputs}
+                  value={firstName}
+                  onChange={setFirstName}
+                />
+              </div>
+              <div className="flex-1">
+                <AuthField
+                  label="Uzvārds (neobligāts)"
                   name="lastName"
+                  disabled={disableInputs}
                   value={lastName}
-                  variant="secondary"
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLastName(e.target.value)}
+                  onChange={setLastName}
                 />
               </div>
             </div>
-            <div className="flex flex-col gap-1">
-              <Label>E-pasta adrese</Label>
-              <Input
-                aria-label="E-pasta adrese"
-                autoComplete="email"
-                className="border-divider border rounded-md py-3"
-                disabled={disableInputs}
-                name="email"
-                type="email"
-                value={email}
-                variant="secondary"
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
-              />
-            </div>
+            <AuthField
+              label="E-pasta adrese"
+              name="email"
+              type="email"
+              autoComplete="email"
+              disabled={disableInputs}
+              value={email}
+              onChange={setEmail}
+            />
           </>
         )}
-        <div className="flex flex-col md:flex-row gap-3">
-          <div className="flex flex-1 flex-col gap-1">
-            <Label>Parole</Label>
-            <div className="relative">
-              <Input
-                aria-label="Parole"
-                autoComplete="password"
-                className="border-divider border rounded-md py-3 pr-10"
-                disabled={disableInputs}
-                name="password"
-                required
-                fullWidth
-                type={isVisible ? "text" : "password"}
-                value={password}
-                variant="secondary"
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
-              />
-              <div className="pointer-events-auto absolute inset-y-0 right-3 flex items-center">
-                <button type="button" onMouseDown={toggleVisibility}>
-                  {isVisible ? (
-                    <IconEyeOff className="text-default-500" size={22}
-                    />
-                  ) : (
-                    <IconEye className="text-default-500" size={22} />
-                  )}
-                </button>
-              </div>
-            </div>
-          </div>
-          {type === "register" && (
-            <div className="flex flex-1 flex-col gap-1">
-              <Label>Apstipriniet paroli</Label>
-              <Input
-                aria-label="Apstipriniet paroli"
-                autoComplete="new-password"
-                className="border-divider border rounded-md py-3"
-                disabled={disableInputs}
-                name="confirmPassword"
-                required
-                type="password"
-                value={repPassword}
-                variant="secondary"
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setRepPassword(e.target.value)}
-              />
-            </div>
+
+        <div className="flex flex-col gap-1.5">
+          <AuthField
+            label="Parole"
+            name="password"
+            autoComplete={
+              type === "register" ? "new-password" : "current-password"
+            }
+            required
+            disabled={disableInputs}
+            type={isVisible ? "text" : "password"}
+            value={password}
+            onChange={setPassword}
+            endContent={
+              <button
+                type="button"
+                className="p-1 text-[#525252] hover:text-[#161616]"
+                aria-label={isVisible ? "Slēpt paroli" : "Rādīt paroli"}
+                onMouseDown={toggleVisibility}
+              >
+                {isVisible ? <IconEyeOff size={20} /> : <IconEye size={20} />}
+              </button>
+            }
+          />
+          {type === "login" && (
+            <p className="text-xs text-[#6f6f6f]">
+              <Link
+                href="/forgot-password"
+                className="text-[#6f6f6f] underline underline-offset-2 decoration-[#6f6f6f]/35 hover:text-[#525252] hover:decoration-[#525252]/70"
+              >
+                Aizmirsi paroli?
+              </Link>
+            </p>
           )}
         </div>
-        <div className="flex justify-center">
-          <GenericButton
-            rounded="lg"
-            variant={type === "register" ? "success" : "primary"}
-            icon={type === "register" ? <IconUserPlus size={22} /> : <IconLogin2 size={22} />}
-            className="w-full"
-            isLoading={
-              loginMutation.status === 'pending' ||
-              registerMutation.status === 'pending' ||
-              isRedirecting
-            }
-            type="submit"
-          >
-            {type === "register" ? "Reģistrēties" : "Pieslēgties"}
-          </GenericButton>
-          {/* <Button
-            className="flex-grow mt-4"
-            color="primary"
-            isLoading={
-              loginMutation.status === 'pending' ||
-              registerMutation.status === 'pending' ||
-              isRedirecting
-            }
-            type="submit"
-          >
-            {type === "register" ? "Reģistrēties" : "Pieslēgties"}
-          </Button> */}
-        </div>
-      </form>
 
-      {error && (
-        <Alert message={error} type="error" onClose={() => setError(null)} />
-      )}
-      <div className="flex items-center gap-4 py-2">
-        <div className="flex-1 border-t border-divider" />
-        <p className="shrink-0 text-small text-default-500">VAI</p>
-        <div className="flex-1 border-t border-divider" />
-      </div>
-      <Suspense>
-        <GoToLoginOrRegister
-          type={type}
-          redirect={redirectParam ?? undefined}
-          onSwitchToLogin={onSwitchToLogin}
-          onSwitchToRegister={onSwitchToRegister}
-        />
-      </Suspense>
+        {type === "register" && (
+          <AuthField
+            label="Apstipriniet paroli"
+            name="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            required
+            disabled={disableInputs}
+            value={repPassword}
+            onChange={setRepPassword}
+          />
+        )}
+
+        {error && (
+          <Alert message={error} type="error" onClose={() => setError(null)} />
+        )}
+
+        <GenericButton
+          className={`mt-2 !h-[44px] w-full !justify-between px-4 text-[0.95rem] !font-normal ${
+            type === "register"
+              ? ""
+              : "!bg-[#0f62fe] hover:!bg-[#0353e9]"
+          }`}
+          rounded="sm"
+          variant={type === "register" ? "success" : "primary"}
+          icon={
+            type === "register" ? (
+              <IconUserPlus size={20} stroke={1.75} />
+            ) : (
+              <IconLogin2 size={20} stroke={1.75} />
+            )
+          }
+          isLoading={
+            loginMutation.status === "pending" ||
+            registerMutation.status === "pending" ||
+            isRedirecting
+          }
+          type="submit"
+        >
+          {type === "register" ? "Reģistrēties" : "Turpināt"}
+        </GenericButton>
+      </form>
     </div>
   );
 }
@@ -309,37 +281,37 @@ function GoToLoginOrRegister({
     : `/register`;
 
   return (
-    <p className="text-center text-small">
+    <p className="text-sm text-[#525252]">
       {type === "register" ? (
         <>
-          Jau ir konts?&nbsp;
+          Jau ir konts?{" "}
           {onSwitchToLogin ? (
             <button
               type="button"
-              className="cursor-pointer border-0 bg-transparent p-0 text-blue-800 underline underline-offset-2 decoration-blue-800/30 hover:decoration-blue-800/90 font-medium"
+              className="cursor-pointer border-0 bg-transparent p-0 font-medium text-blue-800 underline underline-offset-2 decoration-blue-800/30 hover:decoration-blue-800/90"
               onClick={onSwitchToLogin}
             >
               Pieslēgties
             </button>
           ) : (
-            <TextLink color="default" weight="medium" href={loginHref}>
+            <TextLink color="primary" weight="medium" href={loginHref}>
               Pieslēgties
             </TextLink>
           )}
         </>
       ) : (
         <>
-          Nav konta?&nbsp;
+          Nav konta?{" "}
           {onSwitchToRegister ? (
             <button
               type="button"
-              className="cursor-pointer border-0 bg-transparent p-0 text-green-700 underline underline-offset-2 decoration-green-700/30 hover:decoration-green-700/90 font-medium"
+              className="cursor-pointer border-0 bg-transparent p-0 font-medium text-[#8a3ffc] underline underline-offset-2 decoration-[#8a3ffc]/30 hover:decoration-[#8a3ffc]/90"
               onClick={onSwitchToRegister}
             >
               Reģistrēties
             </button>
           ) : (
-            <TextLink color="success" weight="medium" href={registerHref}>
+            <TextLink color="accent" weight="medium" href={registerHref}>
               Reģistrēties
             </TextLink>
           )}

--- a/components/text-link.tsx
+++ b/components/text-link.tsx
@@ -7,7 +7,7 @@ type TextLinkProps = {
     rel?: string;
     disabled?: boolean;
     weight?: "normal" | "medium" | "semibold" | "bold";
-    color?: "default" | "success";
+    color?: "default" | "success" | "accent" | "primary";
     isDisabled?: boolean;
 }
 
@@ -18,6 +18,14 @@ export function TextLink({ children, href, target, rel, disabled, color = "defau
 
     if (color === "success") {
         return <Link href={href} className={`text-green-700 underline underline-offset-2 decoration-green-700/30 hover:decoration-green-700/90 font-${weight}`} target={target} rel={rel}>{children}</Link>
+    }
+
+    if (color === "accent") {
+        return <Link href={href} className={`text-[#8a3ffc] underline underline-offset-2 decoration-[#8a3ffc]/30 hover:decoration-[#8a3ffc]/90 font-${weight}`} target={target} rel={rel}>{children}</Link>
+    }
+
+    if (color === "primary") {
+        return <Link href={href} className={`text-[#0f62fe] underline underline-offset-2 decoration-[#0f62fe]/30 hover:decoration-[#0f62fe]/90 font-${weight}`} target={target} rel={rel}>{children}</Link>
     }
 
     return (

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -73,3 +73,52 @@ export const logoutUser = async (): Promise<ApiResponse<User>> => {
   }
 };
 
+type MessageData = { message: string };
+
+export const requestPasswordReset = async (
+  login: string
+): Promise<ApiResponse<MessageData>> => {
+  const response = await fetch(`${API_HOST}/password-reset/request`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ login }),
+  });
+  return response.json();
+};
+
+export const confirmPasswordReset = async (
+  token: string,
+  password: string
+): Promise<ApiResponse<MessageData>> => {
+  const response = await fetch(`${API_HOST}/password-reset/confirm`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ token, password }),
+  });
+  return response.json();
+};
+
+export const requestEmailVerification = async (): Promise<
+  ApiResponse<MessageData>
+> => {
+  const response = await fetch(`${API_HOST}/email-verification/request`, {
+    method: "POST",
+    credentials: "include",
+  });
+  return response.json();
+};
+
+export const confirmEmailVerification = async (
+  token: string
+): Promise<ApiResponse<MessageData>> => {
+  const response = await fetch(`${API_HOST}/email-verification/confirm`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ token }),
+  });
+  return response.json();
+};
+

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -143,6 +143,54 @@ strong {
   background-color: var(--legacy-content1);
 }
 
+/* Auth inputs: ring lives on the shell so browser autofill cannot thicken one edge */
+.auth-field-shell {
+  background-color: #e8e8e8;
+  box-shadow: inset 0 -1px 0 0 #8d8d8d;
+  transition: background-color 120ms ease, box-shadow 120ms ease;
+}
+
+.auth-field-shell:focus-within {
+  background-color: #f4f4f4;
+  box-shadow: inset 0 0 0 2px #0f62fe;
+}
+
+.auth-field-input {
+  border: 0;
+  outline: none;
+  background-color: transparent;
+  box-shadow: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.auth-field-input:focus,
+.auth-field-input:focus-visible {
+  border: 0;
+  outline: none;
+  box-shadow: none;
+}
+
+.auth-field-input:-webkit-autofill,
+.auth-field-input:-webkit-autofill:hover,
+.auth-field-input:-webkit-autofill:focus,
+.auth-field-input:autofill,
+.auth-field-input:autofill:hover,
+.auth-field-input:autofill:focus {
+  -webkit-text-fill-color: #161616;
+  caret-color: #161616;
+  border: 0;
+  outline: none;
+  /* Paint fill only; never put the focus ring on the input itself */
+  box-shadow: inset 0 0 0 1000px #e8e8e8 !important;
+  transition: background-color 99999s ease-out;
+}
+
+.auth-field-shell:focus-within .auth-field-input:-webkit-autofill,
+.auth-field-shell:focus-within .auth-field-input:autofill {
+  box-shadow: inset 0 0 0 1000px #f4f4f4 !important;
+}
+
 @layer components {
   .input {
     @apply rounded-sm;

--- a/types/proglv.ts
+++ b/types/proglv.ts
@@ -54,6 +54,7 @@ type User = {
   email: string;
   firstname: string | null;
   lastname: string | null;
+  email_verified?: boolean;
 };
 
 type EvalStateUpdate = {


### PR DESCRIPTION
## Summary
- Forgot password, reset password, and verify-email pages wired to the new backend endpoints
- IBM-inspired auth layout with native `AuthField` inputs (no HeroUI)
- Login/register refinements: register accent link, forgot-password under password field, full-width action buttons

## Test plan
- [ ] `/login`, `/register`, `/forgot-password` render correctly on desktop and mobile
- [ ] Forgot password request succeeds against backend; reset page updates password and redirects to login
- [ ] Verify-email page confirms token and shows success/error
- [ ] Auth modal login/register still switches correctly


Made with [Cursor](https://cursor.com)