### PR TITLE
Fix Bugbot verify-email and reset validation

### DIFF
--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -70,6 +70,10 @@ function ResetPasswordForm() {
             setError("Paroles nesakrīt");
             return;
           }
+          if (password.length < 8) {
+            setError("Parolei jābūt vismaz 8 simbolus garai");
+            return;
+          }
           mutation.mutate();
         }}
       >

--- a/app/(auth)/verify-email/page.tsx
+++ b/app/(auth)/verify-email/page.tsx
@@ -22,18 +22,26 @@ function VerifyEmailContent() {
       return;
     }
     let cancelled = false;
-    confirmEmailVerification(token).then((response) => {
-      if (cancelled) {
-        return;
-      }
-      if (response.status === "success") {
-        setStatus("success");
-        setMessage("E-pasts apstiprināts.");
-        return;
-      }
-      setStatus("error");
-      setMessage(response.message || "Neizdevās apstiprināt e-pastu.");
-    });
+    confirmEmailVerification(token)
+      .then((response) => {
+        if (cancelled) {
+          return;
+        }
+        if (response.status === "success") {
+          setStatus("success");
+          setMessage("E-pasts apstiprināts.");
+          return;
+        }
+        setStatus("error");
+        setMessage(response.message || "Neizdevās apstiprināt e-pastu.");
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        setStatus("error");
+        setMessage("Neizdevās apstiprināt e-pastu.");
+      });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
## Summary
- `/verify-email` sets an error state if the confirm request fails or rejects
- `/reset-password` enforces min length 8 client-side to match the copy and backend

## Test plan
- [ ] Open `/verify-email` with API down / invalid response → error message, not endless loading
- [ ] Submit matching passwords shorter than 8 → client error before API call


Made with [Cursor](https://cursor.com)